### PR TITLE
added -h, -l, --version

### DIFF
--- a/lib/m.rb
+++ b/lib/m.rb
@@ -132,7 +132,7 @@ module M
 
         # Parse out ARGV, it should be coming in in a format like `test/test_file.rb:9`
         @file, line = @argv.first.split(':')
-        @line = line.to_i
+        @line ||= line.to_i
 
         # If this file is a directory, not a file, run the tests inside of this directory
         if Dir.exist?(@file)
@@ -161,14 +161,17 @@ module M
           exit
         end
 
-        opts.on '--version', 'Display version.' do
+        opts.on '--version', 'Display the version.' do
           puts "m #{M::VERSION}"
           exit
         end
 
+        opts.on '-l', '--line LINE', Integer, 'Line number for file.' do |line|
+          @line = line
+        end
+
         opts.parse! argv
       end
-
     end
 
     def execute

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -15,4 +15,19 @@ class OptionsTest < MTest
     output = m('--version')
     assert_output /^m #{M::VERSION}/, output
   end
+
+  def test_short_line_option
+    output = m('-l19 examples/minitest_example_test.rb')
+    assert_output /1 tests, 1 assertions/, output
+  end
+
+  def test_long_line_option
+    output = m('--line 19 examples/minitest_example_test.rb')
+    assert_output /1 tests, 1 assertions/, output
+  end
+
+  def test_line_option_has_precedence_over_colon_format
+    output = m('--line 19 examples/minitest_example_test.rb:2')
+    assert_output /1 tests, 1 assertions/, output
+  end
 end


### PR DESCRIPTION
Ended up using optparse. For usage, I put options before files but they could've gone after. Tweak as you like :)

I left alone invalid options since minitest does the same. It's trivial to add error handling i.e. rescue OptionParser::InvalidOption. Here's how a failed option looks:

``` sh
$ m -z
/Users/me/code/fork/m/lib/m.rb:169:in `block in parse_options!': invalid option: -z (OptionParser::InvalidOption)
    from /Users/me/code/fork/m/lib/m.rb:155:in `new'
    from /Users/me/code/fork/m/lib/m.rb:155:in `parse_options!'
    from /Users/me/code/fork/m/lib/m.rb:131:in `parse'
    from /Users/me/code/fork/m/lib/m.rb:119:in `run'
    from /Users/me/code/fork/m/lib/m.rb:105:in `run'
    from bin/m:4:in `<main>'
```
