### PR TITLE
Support Ruby 2.0

### DIFF
--- a/m.gemspec
+++ b/m.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rocco"
   gem.add_development_dependency "minitest"
 
-  gem.required_ruby_version = "~> 1.9"
+  gem.required_ruby_version = ">= 1.9"
 
   gem.summary = description = %q{Run test/unit tests by line number. Metal!}
 end


### PR DESCRIPTION
`m` works fine with Ruby trunk. This relaxes the required 1.9.x Ruby version to allow 2.0+ too.
