### PR TITLE
Gemspec allows for higher versions of method_source as for example the latest pry gem requires this higher version

### DIFF
--- a/lib/m.rb
+++ b/lib/m.rb
@@ -98,7 +98,7 @@
 ### M, your metal test runner
 # Maybe this gem should have a longer name? Metal?
 module M
-  VERSION = "1.1.0"
+  VERSION = "1.1.0" unless defined?(VERSION)
 
   # Accept arguments coming from bin/m and run tests.
   def self.run(argv)

--- a/m.gemspec
+++ b/m.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = M::VERSION
 
-  gem.add_runtime_dependency "method_source", "~> 0.6.7"
+  gem.add_runtime_dependency "method_source", ">= 0.6.7"
   gem.add_runtime_dependency "rake", ">= 0.9.2.2", "< 1.0.0"
   gem.add_development_dependency "activesupport"
   gem.add_development_dependency "rdiscount"


### PR DESCRIPTION
...VERSION constant in M module is only defined unless it already exists (running test with bundler gives already defined constant error otherwise)
