### PR TITLE
Run MiniTest tests in both 1.8 and 1.9

### DIFF
--- a/lib/m.rb
+++ b/lib/m.rb
@@ -188,7 +188,7 @@ module M
 
         # directly run the tests from here and exit with the status of the tests passing or failing
         if defined?(MiniTest)
-          exit MiniTest::Unit.runner.run test_arguments
+          exit MiniTest::Unit.new.run test_arguments
         elsif defined?(Test)
           exit Test::Unit::AutoRunner.run(false, nil, test_arguments)
         else


### PR DESCRIPTION
Pullreq'd upstream in Zeus https://github.com/burke/zeus/pull/146
- In the minitest gem (used only on Ruby 1.8),
  MiniTest::Unit.runner delegates to MiniTest::Unit.new and memoizes the
  result.  This method is not available in the Ruby 1.9 stdlib minitest,
  so we just instantiate a new MiniTest::Unit for cross-compatibility.
- In 1.8, class method MiniTest::Unit.runner:
  https://github.com/seattlerb/minitest/blob/bdbf38df3475dcc8ddd6d11ebede48cdd5f55008/lib/minitest/unit.rb#L808-815
- In 1.9, get a runner instance by constructing a new
- MiniTest::Unit:
  https://github.com/ruby/ruby/blob/v1_9_2_381/lib/minitest/unit.rb#L551-L590
  https://github.com/ruby/ruby/blob/v1_9_3_286/lib/minitest/unit.rb#L531-L883
