### PR TITLE
Fix double run! (Issue #26)

### DIFF
--- a/lib/m.rb
+++ b/lib/m.rb
@@ -100,7 +100,7 @@ module M
 
   # Accept arguments coming from bin/m and run tests, then bail out immediately.
   def self.run(argv)
-    exit Runner.new(argv).run
+    exit! Runner.new(argv).run
   end
 
   ### Runner is in charge of running your tests.


### PR DESCRIPTION
Exit with a BANG! This prevents MiniTest from autoloading the test suite after running a portion of it.

Fixes issue #26.
