### PR TITLE
Fix double run

### DIFF
--- a/lib/m.rb
+++ b/lib/m.rb
@@ -100,6 +100,9 @@ module M
 
   # Accept arguments coming from bin/m and run tests, then bail out immediately.
   def self.run(argv)
+    # sync output since we're going to exit hard and fast
+    $stdout.sync = true
+    $stderr.sync = true
     exit! Runner.new(argv).run
   end
 


### PR DESCRIPTION
In order to fix the double run mentioned in #26 and also the test suite failures from #29, I synchronized `$stdout` and `$stderr` before exiting.

Note that this was because the "Finished ..." output from minitest was being written _after_ the program had exited, so even piping the output of a test run to a file was not including this line.

Thanks to @qrush for the lib and @soffes for the initial fix.

xoxo @ngauthier
