### PR TITLE
It runs more than one method when names start equals

### DIFF
--- a/lib/m.rb
+++ b/lib/m.rb
@@ -186,7 +186,7 @@ module M
         test_names = tests_to_run.map(&:name).join('|')
 
         # set up the args needed for the runner
-        test_arguments = ["-n", "/(#{test_names})/"]
+        test_arguments = ["-n", "/^(#{test_names})$/"]
 
         # directly run the tests from here and exit with the status of the tests passing or failing
         if defined?(MiniTest)

--- a/test/everything_test.rb
+++ b/test/everything_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class EverythingTest < MTest
   def test_runs_entire_test_suite_with_no_arguments
     output = m('')
-    assert_output /12 tests/, output
+    assert_output /13 tests/, output
   end
 
   def test_missing_file_gives_a_decent_error_message
@@ -18,7 +18,7 @@ class EverythingTest < MTest
     assert_output /3 tests/, output
 
     output = m('examples')
-    assert_output /12 tests/, output
+    assert_output /13 tests/, output
   end
 
   def test_blank_file_is_quieter

--- a/test/examples/minitest_example_test.rb
+++ b/test/examples/minitest_example_test.rb
@@ -25,4 +25,10 @@ class TestMeme < MiniTest::Unit::TestCase
     refute_match /^no/i, @meme.will_it_blend?
     refute_match /^lolz/i, @meme.will_it_blend?
   end
+
+  def test_that_kitty_can_eat_two_time
+    assert_equal "OHAI!", @meme.i_can_has_cheezburger?
+    assert_equal "OHAI!", @meme.i_can_has_cheezburger?
+  end
+
 end

--- a/test/minitest_test.rb
+++ b/test/minitest_test.rb
@@ -8,7 +8,7 @@ class MinitestTest < MTest
 
   def test_runs_entire_test_without_line_number
     output = m('examples/minitest_example_test.rb')
-    assert_output /2 tests/, output
+    assert_output /3 tests/, output
   end
 
   def test_run_inside_of_test


### PR DESCRIPTION
When have two methos that start similar and only change the end, then run the two methods.

Example:

test.rb file

```
require 'minitest/autorun'

Ruler = Struct.new(:rule)

class RulerTest < MiniTest::Unit::TestCase
  def test_rule  # line 6
    assert_equal 'rule', Ruler.new('rule').rule   
  end

  def test_rule_empty # line 10
    assert_equal '', Ruler.new('').rule
  end
end
```

When run line 10 that work as expected (run the method _test_rule_empty_)

```
Run options: -n "/(test_rule_empty)/" --seed 45258

# Running tests:

.

Finished tests in 0.000435s, 2297.9895 tests/s, 2297.9895 assertions/s.

1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
```

But, when run line 6

```
m test.rb:6

Run options: -n "/(test_rule)/" --seed 49816

# Running tests:

..

Finished tests in 0.000508s, 3935.8690 tests/s, 3935.8690 assertions/s.

2 tests, 2 assertions, 0 failures, 0 errors, 0 skips
```

Run the two methods.  

Apparently is a problem with the run option "/(test_rule)/"
I think it should be "/^(test_rule)$/"

What do you think?
