### PR TITLE
Support empty test classes

### DIFF
--- a/lib/m.rb
+++ b/lib/m.rb
@@ -209,6 +209,11 @@ module M
         # Spit out helpful message and bail
         STDERR.puts message
         false
+      else
+        # There were no tests at all
+        message = "There were no tests found.\n\n"
+        STDERR.puts message
+        false
       end
     end
 

--- a/test/empty_test.rb
+++ b/test/empty_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class EmptyTest < MTest
+  def test_run_simple_test_by_line_number
+    output = m('examples/empty_example_test.rb')
+    assert !$?.success?
+    assert_match /There were no tests found./, output
+  end
+end

--- a/test/examples/empty_example_test.rb
+++ b/test/examples/empty_example_test.rb
@@ -1,0 +1,4 @@
+require 'test/unit'
+
+class EmptyExampleTest < Test::Unit::TestCase
+end


### PR DESCRIPTION
In the case of an empty test class similar to:

class SomeTest < Test::Unit::TestCase
end

`m` was bombing out because `exit!` expects a non-nil value. The
`Runner#run` method was only returning values in the case of tests that
were found or tests not found within a file that does have tests. The
third case of no tests at all was not being covered and would result in
a `nil` being returned.
