### PR TITLE
Execute Minitest.after_run blocks before exiting

### DIFF
--- a/lib/m.rb
+++ b/lib/m.rb
@@ -10,6 +10,8 @@ module M
     # sync output since we're going to exit hard and fast
     $stdout.sync = true
     $stderr.sync = true
-    exit! Runner.new(argv).run
+    r = Runner.new(argv).run
+    ::Minitest.class_variable_get(:@@after_run).reverse_each(&:call)
+    exit! r
   end
 end


### PR DESCRIPTION
I'm not sure how compatible this is with different versions of minitest.  But `m` should definitely execute `Minitest.after_run` blocks.  It would be nice to run all `at_exit` blocks, but I think that would require changes to minitest or more invasive changes to `m`.