### PR TITLE
Move require outside of class method

### DIFF
--- a/lib/m/test_method.rb
+++ b/lib/m/test_method.rb
@@ -1,3 +1,5 @@
+require "method_source"
+
 module M
   ### Simple data structure for what a test method contains.
   #
@@ -22,7 +24,7 @@ module M
       #
       # The end line should be the number of line breaks in the method source,
       # added to the starting line and subtracted by one.
-      require "method_source"
+      
       end_line = method.source.split("\n").size + start_line - 1
 
       # Shove the given attributes into a new databag


### PR DESCRIPTION
Otherwise if m is installed via gem install and run in a repo that doesn't have 
it inside of its Gemfile, the following error is thrown: 

`cannot load such file -- method_source (LoadError)`

All props on solving this in light of my derping around go to @schneems.