### PR TITLE
Add '-r' option to Parser so directories can be searched for tests recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Want to run the whole test? Just leave off the line number.
 
     1 tests, 2 assertions, 0 failures, 0 errors, 0 skips
 
+If you want to run all the tests in a directory as well as its subdirectories, use the `-r` flag: 
+
+    $ m -r test/models
+    "Searching provided directory for tests recursively"
+    Run options: 
+
+    ..
+
+    Finished in 3.459902s, 45.0880 runs/s, 87.5747 assertions/s.
+
+    156 tests, 303 assertions, 0 failures, 0 errors, 13 skips
+
 
 SUPPORT
 =======

--- a/lib/m/parser.rb
+++ b/lib/m/parser.rb
@@ -77,7 +77,11 @@ module M
     end
 
     def wildcard(type)
-      "#{testable.file}/" + (testable.recursive? ? "**/*#{type}*.rb" : "*#{type}*.rb")
+      if testable.recursive
+        "#{testable.file}/**/*#{type}*.rb"
+      else
+        "#{testable.file}/*#{type}*.rb"
+      end
     end
   end
 end

--- a/lib/m/parser.rb
+++ b/lib/m/parser.rb
@@ -67,8 +67,9 @@ module M
           testable.line = line
         end
 
-        opts.on '-r', 'Search provided directory recursively.' do |line|
+        opts.on '-r', '--recursive DIR', 'Search provided directory recursively.' do |directory|
           testable.recursive = true
+          argv << directory
         end
 
         opts.parse! argv

--- a/lib/m/parser.rb
+++ b/lib/m/parser.rb
@@ -25,7 +25,7 @@ module M
           Rake::TestTask.new(:m_custom) do |t|
             t.libs << 'test'
             t.libs << 'spec'
-            t.test_files = FileList["#{testable.file}/*test*.rb", "#{testable.file}/*spec*.rb"]
+            t.test_files = FileList[wildcard("test"), wildcard("spec")]
           end
           # Invoke the rake task and exit, hopefully it'll work!
           begin
@@ -67,8 +67,17 @@ module M
           testable.line = line
         end
 
+        opts.on '-r', 'Search provided directory recursively.' do |line|
+          p "Searching provided directory for tests recursively"
+          testable.recursive = true
+        end
+
         opts.parse! argv
       end
+    end
+
+    def wildcard(type)
+      "#{testable.file}/" + (testable.recursive? ? "**/*#{type}*.rb" : "*#{type}*.rb")
     end
   end
 end

--- a/lib/m/parser.rb
+++ b/lib/m/parser.rb
@@ -68,7 +68,6 @@ module M
         end
 
         opts.on '-r', 'Search provided directory recursively.' do |line|
-          p "Searching provided directory for tests recursively"
           testable.recursive = true
         end
 

--- a/lib/m/testable.rb
+++ b/lib/m/testable.rb
@@ -1,15 +1,20 @@
 module M
   class Testable
-    attr_accessor :file
+    attr_accessor :file, :recursive
     attr_reader :line
 
-    def initialize(file = "", line = nil)
+    def initialize(file = "", line = nil, recursive = false)
       @file = file
       @line = line
+      @recursive = recursive
     end
 
     def line=(line)
       @line ||= line.to_i
+    end
+
+    def recursive?
+      recursive == true
     end
   end
 end

--- a/lib/m/testable.rb
+++ b/lib/m/testable.rb
@@ -12,9 +12,5 @@ module M
     def line=(line)
       @line ||= line.to_i
     end
-
-    def recursive?
-      recursive == true
-    end
   end
 end

--- a/test/everything_test.rb
+++ b/test/everything_test.rb
@@ -25,9 +25,9 @@ class EverythingTest < MTest
     assert_output(/12 tests/, output)
   end
 
-  def test_running_tests_recursively_within_a_directory
-    output = m('-r examples')
-    assert_output(/15 tests/, output)
+  def test_running_tests_recursively
+    output = m('-r examples/subdir')
+    assert_output(/5 tests/, output)
   end
 
   def test_running_tests_with_failures_within_a_subdirectory

--- a/test/everything_test.rb
+++ b/test/everything_test.rb
@@ -25,11 +25,6 @@ class EverythingTest < MTest
     assert_output(/12 tests/, output)
   end
 
-  def test_running_tests_recursively
-    output = m('-r examples/subdir')
-    assert_output(/5 tests/, output)
-  end
-
   def test_running_tests_with_failures_within_a_subdirectory
     output = m('examples/subdir_with_failures')
     assert_output(/1 tests, 1 assertions, 1 failures/, output)

--- a/test/everything_test.rb
+++ b/test/everything_test.rb
@@ -25,6 +25,11 @@ class EverythingTest < MTest
     assert_output(/12 tests/, output)
   end
 
+  def test_running_tests_recursively_within_a_directory
+    output = m('-r examples')
+    assert_output(/15 tests/, output)
+  end
+
   def test_running_tests_with_failures_within_a_subdirectory
     output = m('examples/subdir_with_failures')
     assert_output(/1 tests, 1 assertions, 1 failures/, output)

--- a/test/examples/subdir/another_subdir/d_test.rb
+++ b/test/examples/subdir/another_subdir/d_test.rb
@@ -1,0 +1,7 @@
+require_relative '../../../test_helper'
+
+class DTest < MTest
+  def test_d
+    assert_equal 1, 1
+  end
+end

--- a/test/examples/subdir/another_subdir/yet_another_subdir/e_test.rb
+++ b/test/examples/subdir/another_subdir/yet_another_subdir/e_test.rb
@@ -1,0 +1,7 @@
+require_relative '../../../../test_helper'
+
+class ETest < MTest
+  def test_e
+    assert_equal 1, 1
+  end
+end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -30,4 +30,14 @@ class OptionsTest < MTest
     output = m('--line 20 examples/minitest_4_example_test.rb:2')
     assert_output(/1 tests, 1 assertions/, output)
   end
+
+  def test_recursive_option
+    output = m('-r examples/subdir')
+    assert_output(/5 tests/, output)
+  end
+
+  def test_recursive_option_without_directory_arg_fails
+    output = m('-r')
+    assert_match(/OptionParser::MissingArgument/, output)
+  end
 end


### PR DESCRIPTION
Hi! First time attempting to contribute something besides readme changes/fixes to an open source project so bear with me. `m` has made my life with Minitest a lot easier but from time to time I've wanted to run a "chunk" of the test suite (like all of the model tests) but passing a directory to `m` just looks for all of the `*test.rb` files in the directory. I added this `-r` flag that gets all of the test files in the passed directory and all of its subdirectories, allowing me to do `m -r test/models/`and get every test in every subdirectory of `models/`. 

If this feature is of any interest to the maintainers, I was wondering if someone might be able to take a look at the test I've written and make sure it's doing what I intended? I'm having a hard time wrapping my head around the test setup (never used `appraisals`, think I understand how the tests work with different frameworks but not sure). 

The number `15` that I hardcoded into the test passes, but I want to make sure I'm counting correctly based on which tests get run and which don't depending on the Framework being used (Minitest 4/5, TestUnit). I tried to write some more specific tests where I was sure about the number of tests that would be called by `m` but ran into various problems with things not being loaded correctly and debugging tools that I'm used to using in these situations not working as expected. I've tested this is an application I'm building at work and on a dummy set of tests and it seems to be working fine there. 