### PR TITLE
Update the 3 gemfiles/*.gemfile.lock files to m 1.4.2. This happened …

### DIFF
--- a/gemfiles/minitest4.gemfile.lock
+++ b/gemfiles/minitest4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    m (1.3.4)
+    m (1.4.2)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -82,4 +82,4 @@ DEPENDENCIES
   rocco
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/gemfiles/minitest5.gemfile.lock
+++ b/gemfiles/minitest5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    m (1.3.4)
+    m (1.4.2)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -72,4 +72,4 @@ DEPENDENCIES
   rocco
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/gemfiles/test_unit_gem.gemfile.lock
+++ b/gemfiles/test_unit_gem.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    m (1.3.4)
+    m (1.4.2)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -82,4 +82,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
…automatically when I ran 'bundle exec rake tests' since the gemfile locks have gemspec :path => "../" and m.gemspec is referencing M::VERSION which is 1.4.2

in reference to #51 

@zamith After speaking with a friend about these failing Travis build for Ruby 2.2.0, we decided that maybe these changes should be merged in before anything else since `m 1.4.2` doesn't seem to be installed correctly w/Ruby 2.2.0 on the Travis builds. Thoughts?