### PR TITLE
Updates the testing gemfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.1.0
   - 2.2.0
   - jruby-1.7.21
+before_install:
+  - gem install bundler
 install:
   - bundle install
   - bundle --gemfile=gemfiles/minitest5.gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,3 @@ DEPENDENCIES
   m!
   rdiscount
   rocco
-
-BUNDLED WITH
-   1.10.6

--- a/gemfiles/minitest4.gemfile.lock
+++ b/gemfiles/minitest4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    m (1.3.4)
+    m (1.4.2)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -82,4 +82,4 @@ DEPENDENCIES
   rocco
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/gemfiles/minitest5.gemfile.lock
+++ b/gemfiles/minitest5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    m (1.3.4)
+    m (1.4.2)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -72,4 +72,4 @@ DEPENDENCIES
   rocco
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/gemfiles/test_unit_gem.gemfile.lock
+++ b/gemfiles/test_unit_gem.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    m (1.3.4)
+    m (1.4.2)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -82,4 +82,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Why:

* It's best they use the latest version of M, to keep the tests useful

This change addresses the need by:

* Upgrading the versions on the Gemfile.locks
* Forcing an install of bundler before running the test, due to
  incompatibilities of the bundler version that was being used in Travis,
  and of Ruby version 2.2.0. (See
  https://github.com/bundler/bundler/issues/3558)