### PR TITLE
Rescue RuntimeError with exit!(), not exit()

### DIFF
--- a/lib/error_tests/error_test.rb
+++ b/lib/error_tests/error_test.rb
@@ -1,0 +1,7 @@
+require_relative "../../test/test_helper.rb"
+
+class ErrorTest < MTest
+  def test_purposeful_error
+    raise RuntimeError
+  end
+end

--- a/lib/m/parser.rb
+++ b/lib/m/parser.rb
@@ -31,8 +31,8 @@ module M
           begin
             Rake::Task['m_custom'].invoke
           rescue RuntimeError
-            exit
-          ensure
+            exit!
+          ensure 
             exit
           end
         else

--- a/test/exit_codes_test.rb
+++ b/test/exit_codes_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class ExitCodesTest < MTest
+  def test_failing_test_returns_1
+    m("examples/subdir_with_failures/a_test")
+    refute $?.success?, "expected exit code to be 1 but it was #{$?.exitstatus}"
+  end
+
+  def test_test_with_error_returns_1
+    m("../lib/error_tests/error_test")
+    refute $?.success?, "expected exit code to be 1 but it was #{$?.exitstatus}"
+  end
+  
+  def test_dir_with_failure_returns_1
+    m("examples/subdir_with_failures")
+    refute $?.success?, "expected exit code to be 1 but it was #{$?.exitstatus}"
+  end
+
+  def test_dir_with_error_returns_1
+    m("../lib/error_tests")
+    refute $?.success?, "expected exit code to be 1 but it was #{$?.exitstatus}"
+  end
+
+  def test_without_errors_or_failures_returns_0
+    m("examples/subdir/a_test")
+    assert $?.success?, "expected exit code to be 0 but it was #{$?.exitstatus}"
+  end
+
+  def test_dir_without_errors_or_failures_returns_0
+    m("examples/subdir")
+    assert $?.success?, "expected exit code to be 0 but it was #{$?.exitstatus}"
+  end
+end


### PR DESCRIPTION
WHY:
In parser.rb, RunTime error is being rescued with exit(). By default
this returns a status code of 0:

http://ruby-doc.org/core-2.3.1/Kernel.html#method-i-exit

CI builds depend on status codes for each step in the build process to
determine whether the build passed or failed. Since exit() is being used
here, test suites that experience runtime errors will still exit with a
0 status code.

By contrast, exit!() defaults to returning a status code of 1 (failure):

http://ruby-doc.org/core-2.3.1/Kernel.html#method-i-exit-21

This is the desired behavior for handling a runtime error during tests.