### PR TITLE
Multiline support: `m tests/test.rb:9:19`

### DIFF
--- a/lib/m/executor.rb
+++ b/lib/m/executor.rb
@@ -12,7 +12,7 @@ module M
 
     def execute
       # Locate tests to run that may be inside of this line. There could be more than one!
-      tests_to_run = tests.within(testable.line)
+      tests_to_run = tests.within(testable.lines)
 
       # If we found any tests,
       if tests_to_run.size > 0
@@ -26,7 +26,7 @@ module M
         runner.run(test_arguments)
       elsif tests.size > 0
         # Otherwise we found no tests on this line, so you need to pick one.
-        message = "No tests found on line #{testable.line}. Valid tests to run:\n\n"
+        message = "No tests found on line #{testable.lines.join(', ')}. Valid tests to run:\n\n"
 
         # For every test ordered by line number,
         # spit out the test name and line number where it starts,

--- a/lib/m/parser.rb
+++ b/lib/m/parser.rb
@@ -15,8 +15,10 @@ module M
       else
         parse_options! argv
 
-        # Parse out ARGV, it should be coming in in a format like `test/test_file.rb:9`
-        testable.file, testable.line = argv.first.split(':')
+        # Parse out ARGV, it should be coming in in a format like `test/test_file.rb:9:19`
+        parsed = argv.first.split(':')
+        testable.file = parsed.shift
+        testable.lines = parsed if testable.lines.none?
 
         # If this file is a directory, not a file, run the tests inside of this directory
         if Dir.exist?(testable.file)
@@ -64,7 +66,7 @@ module M
 
         opts.on '-l', '--line LINE', Integer, 'Line number for file.' do |line|
           p "parsing line #{line}"
-          testable.line = line
+          testable.lines = [line]
         end
 
         opts.on '-r', '--recursive DIR', 'Search provided directory recursively.' do |directory|

--- a/lib/m/test_collection.rb
+++ b/lib/m/test_collection.rb
@@ -17,13 +17,12 @@ module M
 
     # Slice out tests that may be within the given line.
     # Returns a new TestCollection with the results.
-    def within(line)
+    def within(lines)
       # Into a new collection, filter only the tests that...
-      self.class.new(select do |test|
-        # are within the given boundary for this method
-        # or include everything if the line given is zero (no line)
-        line.zero? || (test.start_line..test.end_line).include?(line)
-      end)
+      collection = select do |test|
+        lines.none? || lines.any? { |line| (test.start_line..test.end_line).include?(line) }
+      end
+      self.class.new(collection)
     end
 
     # Used to line up method names in `#sprintf` when `m` aborts

--- a/lib/m/testable.rb
+++ b/lib/m/testable.rb
@@ -1,16 +1,16 @@
 module M
   class Testable
     attr_accessor :file, :recursive
-    attr_reader :line
+    attr_reader :lines
 
-    def initialize(file = "", line = nil, recursive = false)
+    def initialize(file = "", lines = [], recursive = false)
       @file = file
-      @line = line
       @recursive = recursive
+      self.lines = lines
     end
 
-    def line=(line)
-      @line ||= line.to_i
+    def lines=(lines)
+      @lines = lines.map(&:to_i)
     end
   end
 end


### PR DESCRIPTION
My use case for `m` is that I'd like to run multiple test lines at the same time: `m tests/test.rb:9:19` to run both tests on lines *9 and 19*.

I'm submitting the PR without test coverage just to collect the feedback on my feature.
If contributors find it useful, I'll be happy to discuss the details of implementation and add test coverage.

review @zamith @qrush 