### PR TITLE
Adds support for passthrough options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,52 +21,38 @@ GEM
       rake
       thor (>= 0.14.0)
     benchmark-ips (2.1.1)
-    coveralls (0.8.1)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.10.0)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-    docile (1.1.5)
-    domain_name (0.5.24)
-      unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    docile (1.3.1)
     i18n (0.7.0)
-    json (1.8.2)
-    json (1.8.2-java)
+    json (2.2.0)
+    json (2.2.0-java)
     method_source (0.8.2)
-    mime-types (2.5)
     minitest (4.7.5)
     multi_json (1.11.0)
     mustache (1.0.2)
-    netrc (0.10.3)
     rake (10.4.2)
     rdiscount (2.1.8)
     redcarpet (3.3.2)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rocco (0.8.2)
       mustache
       redcarpet
-    simplecov (0.10.0)
-      docile (~> 1.1.0)
-      json (~> 1.8)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
-    term-ansicolor (1.3.0)
+    simplecov-html (0.10.2)
+    term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (0.19.1)
+    thor (0.20.3)
     thread_safe (0.3.5)
     thread_safe (0.3.5-java)
-    tins (1.5.1)
+    tins (1.20.2)
     tzinfo (0.3.44)
-    unf (0.1.4)
-      unf_ext
-    unf (0.1.4-java)
-    unf_ext (0.0.7.1)
 
 PLATFORMS
   java
@@ -83,4 +69,4 @@ DEPENDENCIES
   rocco
 
 BUNDLED WITH
-   1.12.5
+   1.17.2

--- a/gemfiles/minitest4.gemfile.lock
+++ b/gemfiles/minitest4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    m (1.4.2)
+    m (1.5.1)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -19,54 +19,40 @@ GEM
       rake
     atomic (1.1.14)
     atomic (1.1.14-java)
-    coveralls (0.8.1)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.10.0)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-    docile (1.1.5)
-    domain_name (0.5.24)
-      unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    docile (1.3.1)
     i18n (0.6.9)
-    json (1.8.2)
-    json (1.8.2-java)
-    method_source (0.8.2)
-    mime-types (2.5)
+    json (2.2.0)
+    json (2.2.0-java)
+    method_source (0.9.2)
     minitest (4.7.5)
     multi_json (1.8.4)
     mustache (1.0.2)
-    netrc (0.10.3)
     rake (10.1.1)
     rdiscount (2.1.8)
     redcarpet (3.3.2)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rocco (0.8.2)
       mustache
       redcarpet
-    simplecov (0.10.0)
-      docile (~> 1.1.0)
-      json (~> 1.8)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
-    term-ansicolor (1.3.0)
+    simplecov-html (0.10.2)
+    term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (0.19.1)
+    thor (0.20.3)
     thread_safe (0.1.3)
       atomic
     thread_safe (0.1.3-java)
       atomic
-    tins (1.5.1)
+    tins (1.20.2)
     tzinfo (0.3.38)
-    unf (0.1.4)
-      unf_ext
-    unf (0.1.4-java)
-    unf_ext (0.0.7.1)
 
 PLATFORMS
   java
@@ -82,4 +68,4 @@ DEPENDENCIES
   rocco
 
 BUNDLED WITH
-   1.11.2
+   1.17.2

--- a/gemfiles/minitest5.gemfile.lock
+++ b/gemfiles/minitest5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    m (1.4.2)
+    m (1.5.1)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -14,49 +14,35 @@ GEM
     appraisal (0.5.2)
       bundler
       rake
-    coveralls (0.8.1)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.10.0)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-    docile (1.1.5)
-    domain_name (0.5.24)
-      unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    docile (1.3.1)
     i18n (0.6.9)
-    json (1.8.2)
-    json (1.8.2-java)
-    method_source (0.8.2)
-    mime-types (2.5)
+    json (2.2.0)
+    json (2.2.0-java)
+    method_source (0.9.2)
     minitest (5.3.1)
     multi_json (1.8.4)
     mustache (1.0.2)
-    netrc (0.10.3)
     rake (10.1.1)
     rdiscount (2.1.8)
     redcarpet (3.3.2)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rocco (0.8.2)
       mustache
       redcarpet
-    simplecov (0.10.0)
-      docile (~> 1.1.0)
-      json (~> 1.8)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
-    term-ansicolor (1.3.0)
+    simplecov-html (0.10.2)
+    term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (0.19.1)
-    tins (1.5.1)
-    unf (0.1.4)
-      unf_ext
-    unf (0.1.4-java)
-    unf_ext (0.0.7.1)
+    thor (0.20.3)
+    tins (1.20.2)
 
 PLATFORMS
   java
@@ -72,4 +58,4 @@ DEPENDENCIES
   rocco
 
 BUNDLED WITH
-   1.11.2
+   1.17.2

--- a/gemfiles/test_unit_gem.gemfile.lock
+++ b/gemfiles/test_unit_gem.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    m (1.4.2)
+    m (1.5.1)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 
@@ -18,55 +18,41 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    coveralls (0.8.2)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.10.0)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-    docile (1.1.5)
-    domain_name (0.5.24)
-      unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    docile (1.3.1)
     i18n (0.7.0)
-    json (1.8.3)
-    json (1.8.3-java)
-    method_source (0.8.2)
-    mime-types (2.6.1)
+    json (1.8.6)
+    json (1.8.6-java)
+    method_source (0.9.2)
     minitest (5.7.0)
     mustache (1.0.2)
-    netrc (0.10.3)
     power_assert (0.2.4)
     rake (10.4.2)
     rdiscount (2.1.8)
     redcarpet (3.3.2)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rocco (0.8.2)
       mustache
       redcarpet
-    simplecov (0.10.0)
-      docile (~> 1.1.0)
-      json (~> 1.8)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
-    term-ansicolor (1.3.2)
+    simplecov-html (0.10.2)
+    term-ansicolor (1.7.1)
       tins (~> 1.0)
     test-unit (3.1.2)
       power_assert
-    thor (0.19.1)
+    thor (0.20.3)
     thread_safe (0.3.5)
     thread_safe (0.3.5-java)
-    tins (1.5.4)
+    tins (1.20.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf (0.1.4-java)
-    unf_ext (0.0.7.1)
 
 PLATFORMS
   java
@@ -82,4 +68,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.11.2
+   1.17.2

--- a/lib/m/executor.rb
+++ b/lib/m/executor.rb
@@ -23,7 +23,7 @@ module M
         test_arguments = ["-n", "/^(#{test_names})$/"]
 
         # directly run the tests from here and exit with the status of the tests passing or failing
-        runner.run(test_arguments)
+        runner.run(test_arguments + testable.passthrough_options)
       elsif tests.size > 0
         # Otherwise we found no tests on this line, so you need to pick one.
         message = "No tests found on line #{testable.lines.join(', ')}. Valid tests to run:\n\n"

--- a/lib/m/parser.rb
+++ b/lib/m/parser.rb
@@ -15,10 +15,17 @@ module M
       else
         parse_options! argv
 
-        # Parse out ARGV, it should be coming in in a format like `test/test_file.rb:9:19`
-        parsed = argv.first.split(':')
-        testable.file = parsed.shift
-        testable.lines = parsed if testable.lines.none?
+        if argv.first.start_with?("--")
+          exec "rake test #{argv.join}"
+          exit 0
+        else
+          # Parse out ARGV, it should be coming in in a format like `test/test_file.rb:9:19`
+          parsed = argv.shift.split(':')
+          testable.file = parsed.shift
+          testable.lines = parsed if testable.lines.none?
+          # Anything else on ARGV will be passed along to the runner
+          testable.passthrough_options = argv
+        end
 
         # If this file is a directory, not a file, run the tests inside of this directory
         if Dir.exist?(testable.file)

--- a/lib/m/testable.rb
+++ b/lib/m/testable.rb
@@ -1,11 +1,12 @@
 module M
   class Testable
-    attr_accessor :file, :recursive
+    attr_accessor :file, :recursive, :passthrough_options
     attr_reader :lines
 
     def initialize(file = "", lines = [], recursive = false)
       @file = file
       @recursive = recursive
+      @passthrough_options = []
       self.lines = lines
     end
 

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -40,4 +40,19 @@ class OptionsTest < MTest
     output = m('-r')
     assert_match(/OptionParser::MissingArgument/, output)
   end
+
+  def test_passthrough_options
+    output = m('-- --verbose')
+    assert_output(/0 errors/, output)
+  end
+
+  def test_passthrough_options_with_file
+    output = m('examples/minitest_4_example_test.rb -- --verbose')
+    assert_output(/3 tests, 9 assertions/, output)
+  end
+
+  def test_passthrough_options_with_file_and_other_options
+    output = m('--line 20 examples/minitest_4_example_test.rb -- --verbose')
+    assert_output(/1 tests, 1 assertions/, output)
+  end
 end


### PR DESCRIPTION
Why:

* There are some options, such as the seed that we might want to pass
  down to the actual runner

This change addresses the need by:

* Taking any option that is not supported by m and passing it down to
  the runner