### PR TITLE
README: Show build status of master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 M.RB
 
-[![Gem Version](https://badge.fury.io/rb/m.svg)](https://rubygems.org/gems/m) [![Code Climate](https://codeclimate.com/github/qrush/m.svg)](https://codeclimate.com/github/qrush/m) [![Build Status](https://travis-ci.org/qrush/m.svg)](https://travis-ci.org/qrush/m) [![Coverage Status](https://coveralls.io/repos/qrush/m/badge.svg?branch=master)](https://coveralls.io/r/qrush/m)
+[![Gem Version](https://badge.fury.io/rb/m.svg)](https://rubygems.org/gems/m) [![Code Climate](https://codeclimate.com/github/qrush/m.svg)](https://codeclimate.com/github/qrush/m) [![Build Status](https://travis-ci.org/qrush/m.svg?branch=master)](https://travis-ci.org/qrush/m) [![Coverage Status](https://coveralls.io/repos/qrush/m/badge.svg?branch=master)](https://coveralls.io/r/qrush/m)
 
 
 ----


### PR DESCRIPTION
This change makes the CI badge show the correct status of the master branch.

Sometimes, other branches fail, such as dependency updates by bots. That should not reflect badly on the README's badge.