### PR TITLE
Correct gem version in gemfile lock files

### DIFF
--- a/gemfiles/minitest4.gemfile.lock
+++ b/gemfiles/minitest4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    m (1.6.0)
+    m (1.6.1)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 

--- a/gemfiles/minitest5.gemfile.lock
+++ b/gemfiles/minitest5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    m (1.6.0)
+    m (1.6.1)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 

--- a/gemfiles/test_unit_gem.gemfile.lock
+++ b/gemfiles/test_unit_gem.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    m (1.6.0)
+    m (1.6.1)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
 


### PR DESCRIPTION
This should fix the build, which is failing because the `gemfile/*.gemfile.lock` files used in CI are referencing a version of `m` that is no longer defined in the repo.