### PR TITLE
Expand Ruby and Platform Coverage

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -10,27 +10,48 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         gemfile:
           - minitest4
           - minitest5
           - test_unit_gem
+        os:
+          - ubuntu-latest
+          - macos-latest
         ruby:
           - ruby-2.7
           - ruby-3.0
           - ruby-3.1
+          - ruby-head
+          - jruby
+          # - jruby-9.1
+          # - jruby-9.2
+          # - jruby-9.3
+          # - jruby-9.4
+          # - jruby-head
           - truffleruby
+          # - truffleruby-19
+          # - truffleruby-20
+          # - truffleruby-21
+          # - truffleruby-22
+          # - truffleruby-head
+          - truffleruby+graalvm
+          # - truffleruby+graalvm-21
+          # - truffleruby+graalvm-22
+          # - truffleruby+graalvm-23
+          # - truffleruby+graalvm-head
+    runs-on: ${{ matrix.os }}
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Test
-        run: bundle exec rake
+        run: bundle exec rake test

--- a/.github/workflows/standard-rb.yml
+++ b/.github/workflows/standard-rb.yml
@@ -1,0 +1,14 @@
+name: StandardRB
+
+jobs:
+  standard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Standard
+        run: bundle exec rake standard


### PR DESCRIPTION
Add JRuby ruby version.
Add TruffleRuby with GraalVM ruby version.
Add Mac OS operating system.
Update Ruby CI workflow to run test rake task (without standard).
Add new StandardRB workflow (only runs once, uses current ruby).