### PR TITLE
Remove Rake version in dependency

### DIFF
--- a/m.gemspec
+++ b/m.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.version = M::VERSION
 
   gem.add_runtime_dependency "method_source", ">= 0.6.7"
-  gem.add_runtime_dependency "rake", ">= 0.9.2.2"
+  gem.add_runtime_dependency "rake"
 
   gem.add_development_dependency "activesupport"
   gem.add_development_dependency "standard"


### PR DESCRIPTION
The library now requires Ruby 2.7, which ships with Rake 13. No need to specify a minimum version anymore.