### PR TITLE
Work with minitest 5.19+

### DIFF
--- a/lib/m/frameworks.rb
+++ b/lib/m/frameworks.rb
@@ -1,7 +1,13 @@
 module M
   class Frameworks
     def self.minitest_version_major
-      defined?(Minitest) ? Minitest::Unit::VERSION.slice(/\d+/) : nil
+      if defined?(Minitest)
+        if defined?(Minitest::Unit::VERSION)
+          Minitest::Unit::VERSION.slice(/\d+/)
+        elsif defined?(Minitest::VERSION)
+          Minitest::VERSION.slice(/\d+/)
+        end
+      end
     end
 
     def self.minitest5?


### PR DESCRIPTION
Minitest 5.19 broke backwards compatibility and removed the Minitest::Unit::VERSION constant.  This uses the Minitest::VERSION constant if the Minitest::Unit::VERSION constant is not available.